### PR TITLE
Update .bashrc

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -1,4 +1,7 @@
 . /usr/share/bash-completion/bash_completion
+if [ $? -ne 0 ]; then
+	return
+fi
 
 shopt -s histappend
 


### PR DESCRIPTION
Exit when failed to import bash_completion.